### PR TITLE
Patch for ReGrowth: Aspen Forests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/Source/ExpandedWoodworking/obj/Release/.NETFramework,Version=v4.7.2.AssemblyAttributes.cs

--- a/1.2/Patches/ReGrowth.xml
+++ b/1.2/Patches/ReGrowth.xml
@@ -3,7 +3,20 @@
 	<!-- Author: KennethSamael  Edited by: Adventurer -->
 	<!-- Deals with the following mods from the ReGrowth series: Boreal Forest Expanion, Cold Bog Expansion, Temperate Forest Expansion, Tundra Expansion, Wasteland, Volcanic Ice Sheet - Beta -->
 	
-	<!-- Boreal -->
+  <!-- Aspen Forests -->
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>ReGrowth: Aspen Forests</li>
+    </mods>
+    <match Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="RG-AF_Plant_TreeAspenRed" or defName="RG-AF_Plant_TreeAspenYellow"]/plant</xpath>
+      <value>
+        <harvestedThingDef>WoodLog_Birch</harvestedThingDef>
+      </value>
+    </match>
+  </Operation>
+
+  <!-- Boreal -->
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>[HLX] ReGrowth - Boreal Forest Expansion</li>


### PR DESCRIPTION
Noticed the Aspen trees were missing from the ReGrowth patch file, so I added them. Made them drop birch wood, to make it simple, since the trees are so alike.